### PR TITLE
[NIT] Update rust-secp256k1-zkp to mimblewimble/rust-secp256k1-zkp latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,8 +1215,8 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.7"
-source = "git+https://github.com/mwcproject/rust-secp256k1-zkp#8b7870c925857d015a4323aec0204d2efca7286a"
+version = "0.7.9"
+source = "git+https://github.com/mwcproject/rust-secp256k1-zkp?branch=mimblewimble#60a8addc2c1f9e5010202bbf43b8301a5f51f807"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1225,7 +1225,7 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1307,7 +1307,7 @@ dependencies = [
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_secp256k1zkp 0.7.7 (git+https://github.com/mwcproject/rust-secp256k1-zkp)",
+ "grin_secp256k1zkp 0.7.9 (git+https://github.com/mwcproject/rust-secp256k1-zkp?branch=mimblewimble)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3446,11 +3446,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3611,7 +3606,7 @@ dependencies = [
 "checksum gimli 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 "checksum git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum grin_secp256k1zkp 0.7.7 (git+https://github.com/mwcproject/rust-secp256k1-zkp)" = "<none>"
+"checksum grin_secp256k1zkp 0.7.9 (git+https://github.com/mwcproject/rust-secp256k1-zkp?branch=mimblewimble)" = "<none>"
 "checksum h2 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 "checksum hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
 "checksum hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
@@ -3859,7 +3854,6 @@ dependencies = [
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 "checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
-"checksum zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4090487fa66630f7b166fba2bbb525e247a5449f41c468cc1d98f8ae6ac03120"
 "checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -89,20 +89,19 @@ fn tx_double_ser_deser() {
 }
 
 #[test]
-#[should_panic(expected = "Keychain Error")]
 fn test_zero_commit_fails() {
 	let keychain = ExtKeychain::from_random_seed(false).unwrap();
 	let builder = ProofBuilder::new(&keychain);
 	let key_id1 = ExtKeychain::derive_key_id(1, 1, 0, 0, 0);
 
 	// blinding should fail as signing with a zero r*G shouldn't work
-	build::transaction(
+	let res = build::transaction(
 		KernelFeatures::Plain { fee: 0 },
 		vec![input(10, key_id1.clone()), output(10, key_id1)],
 		&keychain,
 		&builder,
-	)
-	.unwrap();
+	);
+	assert!(res.is_err());
 }
 
 fn verifier_cache() -> Arc<RwLock<dyn VerifierCache>> {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -33,5 +33,6 @@ zeroize = "0.9"
 git = "https://github.com/mwcproject/rust-secp256k1-zkp"
 #tag = "grin_integration_28"
 #path = "../../rust-secp256k1-zkp"
-version = "0.7.7"
+#version = "0.7.7"
+branch = "mimblewimble"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
Related PR in `rust-secp256k1-zkp`: https://github.com/mwcproject/rust-secp256k1-zkp/pull/1
Update node dependency to latest `rust-secp256k1-zkp` version.

[`nit` branch only at this time, to be updated to master branch in the future, no later than delivering the whole NIT feature.]
