### PR TITLE
Adaptation for simple secp256k1 context w/o precomputation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,8 +1356,8 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.9"
-source = "git+https://github.com/mwcproject/rust-secp256k1-zkp#63c81977c6d3ff04332bb9b34a4d8ea959d92d74"
+version = "0.7.10"
+source = "git+https://github.com/mwcproject/rust-secp256k1-zkp#7fec028ecdeaab3b7b1dc6c6310c9cc05042c5d9"
 dependencies = [
  "arrayvec 0.3.25",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "grin_secp256k1zkp"
 version = "0.7.10"
-source = "git+https://github.com/mwcproject/rust-secp256k1-zkp#7fec028ecdeaab3b7b1dc6c6310c9cc05042c5d9"
+source = "git+https://github.com/mwcproject/rust-secp256k1-zkp#d095616130874b3882880eab758ac2df435c029a"
 dependencies = [
  "arrayvec 0.3.25",
  "cc",

--- a/chain/tests/nrd_validation_rules.rs
+++ b/chain/tests/nrd_validation_rules.rs
@@ -118,7 +118,7 @@ fn process_block_nrd_validation() -> Result<(), Error> {
 	let excess = BlindingFactor::rand();
 	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+	let pubkey = &kernel.excess.to_pubkey().unwrap();
 	kernel.excess_sig =
 		aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 	kernel.verify().unwrap();
@@ -234,7 +234,7 @@ fn process_block_nrd_validation_relative_height_1() -> Result<(), Error> {
 	let excess = BlindingFactor::rand();
 	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+	let pubkey = &kernel.excess.to_pubkey().unwrap();
 	kernel.excess_sig =
 		aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 	kernel.verify().unwrap();
@@ -333,7 +333,7 @@ fn process_block_nrd_validation_fork() -> Result<(), Error> {
 	let excess = BlindingFactor::rand();
 	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+	let pubkey = &kernel.excess.to_pubkey().unwrap();
 	kernel.excess_sig =
 		aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 	kernel.verify().unwrap();

--- a/chain/tests/nrd_validation_rules.rs
+++ b/chain/tests/nrd_validation_rules.rs
@@ -115,8 +115,8 @@ fn process_block_nrd_validation() -> Result<(), Error> {
 	let msg = kernel.msg_to_sign().unwrap();
 
 	// // Generate a kernel with public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp()).unwrap();
+	let excess = BlindingFactor::rand();
+	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
 	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
 	kernel.excess_sig =
@@ -231,8 +231,8 @@ fn process_block_nrd_validation_relative_height_1() -> Result<(), Error> {
 	let msg = kernel.msg_to_sign().unwrap();
 
 	// // Generate a kernel with public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp()).unwrap();
+	let excess = BlindingFactor::rand();
+	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
 	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
 	kernel.excess_sig =
@@ -330,8 +330,8 @@ fn process_block_nrd_validation_fork() -> Result<(), Error> {
 	let msg = kernel.msg_to_sign().unwrap();
 
 	// // Generate a kernel with public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp()).unwrap();
+	let excess = BlindingFactor::rand();
+	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
 	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
 	kernel.excess_sig =

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -815,10 +815,13 @@ impl Block {
 			let secp = secp.lock();
 			let over_commit = secp.commit_value(reward(self.total_fees(), self.header.height))?;
 
-			let out_adjust_sum =
-				secp.commit_sum(map_vec!(cb_outs, |x| x.commitment()), vec![over_commit])?;
+			let out_adjust_sum = secp::Secp256k1::commit_sum(
+				map_vec!(cb_outs, |x| x.commitment()),
+				vec![over_commit],
+			)?;
 
-			let kerns_sum = secp.commit_sum(cb_kerns.iter().map(|x| x.excess).collect(), vec![])?;
+			let kerns_sum =
+				secp::Secp256k1::commit_sum(cb_kerns.iter().map(|x| x.excess).collect(), vec![])?;
 
 			// Verify the kernel sum equals the output sum accounting for block fees.
 			if kerns_sum != out_adjust_sum {

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -73,7 +73,7 @@ pub trait Committed {
 			let secp = secp.lock();
 			let mut commits = vec![kernel_sum];
 			if *offset != BlindingFactor::zero() {
-				let key = offset.secret_key(&secp)?;
+				let key = offset.secret_key()?;
 				let offset_commit = secp.commit(0, key)?;
 				commits.push(offset_commit);
 			}
@@ -161,8 +161,8 @@ pub fn sum_kernel_offsets(
 ) -> Result<BlindingFactor, Error> {
 	let secp = static_secp_instance();
 	let secp = secp.lock();
-	let positive = to_secrets(positive, &secp);
-	let negative = to_secrets(negative, &secp);
+	let positive = to_secrets(positive);
+	let negative = to_secrets(negative);
 
 	if positive.is_empty() {
 		Ok(BlindingFactor::zero())
@@ -172,9 +172,9 @@ pub fn sum_kernel_offsets(
 	}
 }
 
-fn to_secrets(bf: Vec<BlindingFactor>, secp: &secp::Secp256k1) -> Vec<SecretKey> {
+fn to_secrets(bf: Vec<BlindingFactor>) -> Vec<SecretKey> {
 	bf.into_iter()
 		.filter(|x| *x != BlindingFactor::zero())
-		.filter_map(|x| x.secret_key(&secp).ok())
+		.filter_map(|x| x.secret_key().ok())
 		.collect::<Vec<_>>()
 }

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -77,7 +77,7 @@ pub trait Committed {
 				let offset_commit = secp.commit(0, key)?;
 				commits.push(offset_commit);
 			}
-			secp.commit_sum(commits, vec![])?
+			secp::Secp256k1::commit_sum(commits, vec![])?
 		};
 
 		Ok((kernel_sum, kernel_sum_plus_offset))
@@ -147,9 +147,7 @@ pub fn sum_commits(
 	let zero_commit = secp_static::commit_to_zero_value();
 	positive.retain(|x| *x != zero_commit);
 	negative.retain(|x| *x != zero_commit);
-	let secp = static_secp_instance();
-	let secp = secp.lock();
-	Ok(secp.commit_sum(positive, negative)?)
+	Ok(secp::Secp256k1::commit_sum(positive, negative)?)
 }
 
 /// Utility function to take sets of positive and negative kernel offsets as
@@ -159,15 +157,13 @@ pub fn sum_kernel_offsets(
 	positive: Vec<BlindingFactor>,
 	negative: Vec<BlindingFactor>,
 ) -> Result<BlindingFactor, Error> {
-	let secp = static_secp_instance();
-	let secp = secp.lock();
 	let positive = to_secrets(positive);
 	let negative = to_secrets(negative);
 
 	if positive.is_empty() {
 		Ok(BlindingFactor::zero())
 	} else {
-		let sum = secp.blind_sum(positive, negative)?;
+		let sum = secp::Secp256k1::blind_sum(positive, negative)?;
 		Ok(BlindingFactor::from_secret_key(sum))
 	}
 }

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -1530,12 +1530,12 @@ pub fn deaggregate(mk_tx: Transaction, txs: &[Transaction]) -> Result<Transactio
 		let positive_key = vec![mk_tx.offset]
 			.into_iter()
 			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
+			.filter_map(|x| x.secret_key().ok())
 			.collect::<Vec<_>>();
 		let negative_keys = kernel_offsets
 			.into_iter()
 			.filter(|x| *x != BlindingFactor::zero())
-			.filter_map(|x| x.secret_key(&secp).ok())
+			.filter_map(|x| x.secret_key().ok())
 			.collect::<Vec<_>>();
 
 		if positive_key.is_empty() && negative_keys.is_empty() {

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -243,8 +243,8 @@ pub fn verify_partial_sig(
 /// let out_commit = output.commitment();
 /// let features = KernelFeatures::HeightLocked{fee: 0, lock_height: height};
 /// let msg = features.kernel_sig_msg().unwrap();
-/// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
-/// let pubkey = excess.to_pubkey(&secp).unwrap();
+/// let excess = Secp256k1::commit_sum(vec![out_commit], vec![over_commit]).unwrap();
+/// let pubkey = excess.to_pubkey().unwrap();
 /// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, None, Some(&pubkey)).unwrap();
 /// ```
 
@@ -308,8 +308,8 @@ where
 /// let out_commit = output.commitment();
 /// let features = KernelFeatures::HeightLocked{fee: 0, lock_height: height};
 /// let msg = features.kernel_sig_msg().unwrap();
-/// let excess = secp.commit_sum(vec![out_commit], vec![over_commit]).unwrap();
-/// let pubkey = excess.to_pubkey(&secp).unwrap();
+/// let excess = Secp256k1::commit_sum(vec![out_commit], vec![over_commit]).unwrap();
+/// let pubkey = excess.to_pubkey().unwrap();
 /// let sig = aggsig::sign_from_key_id(&secp, &keychain, &msg, value, &key_id, None, Some(&pubkey)).unwrap();
 ///
 /// // Verify the signature from the excess commit
@@ -324,7 +324,7 @@ pub fn verify_single_from_commit(
 	msg: &Message,
 	commit: &Commitment,
 ) -> Result<(), Error> {
-	let pubkey = commit.to_pubkey(secp)?;
+	let pubkey = commit.to_pubkey()?;
 	if !verify_single(secp, sig, msg, None, &pubkey, Some(&pubkey), false) {
 		return Err(ErrorKind::Signature("Signature validation error".to_string()).into());
 	}

--- a/core/src/libtx/aggsig.rs
+++ b/core/src/libtx/aggsig.rs
@@ -74,7 +74,7 @@ pub fn create_secnonce(secp: &Secp256k1) -> Result<SecretKey, Error> {
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::SignOnly);
 /// let secret_nonce = aggsig::create_secnonce(&secp).unwrap();
-/// let secret_key = SecretKey::new(&secp, &mut thread_rng());
+/// let secret_key = SecretKey::new(&mut thread_rng());
 /// let pub_nonce_sum = PublicKey::from_secret_key(&secp, &secret_nonce).unwrap();
 /// // ... Add all other participating nonces
 /// let pub_key_sum = PublicKey::from_secret_key(&secp, &secret_key).unwrap();
@@ -144,7 +144,7 @@ pub fn calculate_partial_sig(
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::Full);
 /// let secret_nonce = aggsig::create_secnonce(&secp).unwrap();
-/// let secret_key = SecretKey::new(&secp, &mut thread_rng());
+/// let secret_key = SecretKey::new(&mut thread_rng());
 /// let pub_nonce_sum = PublicKey::from_secret_key(&secp, &secret_nonce).unwrap();
 /// // ... Add all other participating nonces
 /// let pub_key_sum = PublicKey::from_secret_key(&secp, &secret_key).unwrap();
@@ -359,7 +359,7 @@ pub fn verify_single_from_commit(
 ///
 /// let secp = Secp256k1::with_caps(ContextFlag::Full);
 /// let secret_nonce = aggsig::create_secnonce(&secp).unwrap();
-/// let secret_key = SecretKey::new(&secp, &mut thread_rng());
+/// let secret_key = SecretKey::new(&mut thread_rng());
 /// let pub_nonce_sum = PublicKey::from_secret_key(&secp, &secret_nonce).unwrap();
 /// // ... Add all other participating nonces
 /// let pub_key_sum = PublicKey::from_secret_key(&secp, &secret_key).unwrap();
@@ -454,7 +454,7 @@ pub fn sign_with_blinding(
 	blinding: &BlindingFactor,
 	pubkey_sum: Option<&PublicKey>,
 ) -> Result<Signature, Error> {
-	let skey = &blinding.secret_key(&secp)?;
+	let skey = &blinding.secret_key()?;
 	let sig = aggsig::sign_single(secp, &msg, skey, None, None, None, pubkey_sum, None)?;
 	Ok(sig)
 }

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -216,7 +216,7 @@ where
 	let excess = BlindingFactor::rand();
 	let skey = excess.secret_key()?;
 	kernel.excess = keychain.secp().commit(0, skey)?;
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp())?;
+	let pubkey = &kernel.excess.to_pubkey()?;
 	kernel.excess_sig = aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey))?;
 	kernel.verify()?;
 	transaction_with_kernel(elems, kernel, excess, keychain, builder)
@@ -246,7 +246,7 @@ where
 
 	// Update tx with new kernel and offset.
 	let mut tx = tx.replace_kernel(kernel);
-	tx.offset = blind_sum.split(&excess, &keychain.secp())?;
+	tx.offset = blind_sum.split(&excess)?;
 	Ok(tx)
 }
 

--- a/core/src/libtx/build.rs
+++ b/core/src/libtx/build.rs
@@ -213,8 +213,8 @@ where
 	let msg = kernel.msg_to_sign()?;
 
 	// Generate kernel public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp())?;
+	let excess = BlindingFactor::rand();
+	let skey = excess.secret_key()?;
 	kernel.excess = keychain.secp().commit(0, skey)?;
 	let pubkey = &kernel.excess.to_pubkey(&keychain.secp())?;
 	kernel.excess_sig = aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey))?;

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -436,7 +436,7 @@ impl ProofBuild for ViewKey {
 			key = key.ckd_pub(&secp, &mut hasher, child_number)?;
 		}
 		let pub_key = key.commit(secp, amount, switch)?;
-		if commit.to_pubkey(&secp)? == pub_key {
+		if commit.to_pubkey()? == pub_key {
 			Ok(Some((id, switch)))
 		} else {
 			Ok(None)

--- a/core/src/libtx/proof.rs
+++ b/core/src/libtx/proof.rs
@@ -146,9 +146,7 @@ where
 
 		let private_hash = blake2b(32, &[], &private_root_key.0).as_bytes().to_vec();
 
-		let public_root_key = keychain
-			.public_root_key()
-			.serialize_vec(keychain.secp(), true);
+		let public_root_key = keychain.public_root_key().serialize_vec(true);
 		let rewind_hash = blake2b(32, &[], &public_root_key[..]).as_bytes().to_vec();
 
 		Self {
@@ -165,7 +163,7 @@ where
 			&self.rewind_hash
 		};
 		let res = blake2b(32, &commit.0, hash);
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
+		SecretKey::from_slice(res.as_bytes()).map_err(|e| {
 			ErrorKind::RangeProof(format!(
 				"Unable to extract nonce from commit {:?}, {}",
 				commit, e
@@ -283,7 +281,7 @@ where
 
 	fn nonce(&self, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.root_hash);
-		SecretKey::from_slice(self.keychain.secp(), res.as_bytes()).map_err(|e| {
+		SecretKey::from_slice(res.as_bytes()).map_err(|e| {
 			ErrorKind::RangeProof(format!(
 				"Unable to extract nonce from commit {:?}, {}",
 				commit, e
@@ -369,9 +367,9 @@ where
 }
 
 impl ProofBuild for ViewKey {
-	fn rewind_nonce(&self, secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
+	fn rewind_nonce(&self, _secp: &Secp256k1, commit: &Commitment) -> Result<SecretKey, Error> {
 		let res = blake2b(32, &commit.0, &self.rewind_hash);
-		SecretKey::from_slice(secp, res.as_bytes()).map_err(|e| {
+		SecretKey::from_slice(res.as_bytes()).map_err(|e| {
 			ErrorKind::RangeProof(format!(
 				"Unable to rewind nonce for commit {:?}, {}",
 				commit, e

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -59,7 +59,7 @@ where
 	let msg = features.kernel_sig_msg()?;
 	let sig = match test_mode {
 		true => {
-			let test_nonce = secp::key::SecretKey::from_slice(&secp, &[1; 32])?;
+			let test_nonce = secp::key::SecretKey::from_slice(&[1; 32])?;
 			aggsig::sign_from_key_id(
 				&secp,
 				keychain,

--- a/core/src/libtx/reward.rs
+++ b/core/src/libtx/reward.rs
@@ -52,8 +52,8 @@ where
 	let secp = secp.lock();
 	let over_commit = secp.commit_value(reward(fees, height))?;
 	let out_commit = output.commitment();
-	let excess = secp.commit_sum(vec![out_commit], vec![over_commit])?;
-	let pubkey = excess.to_pubkey(&secp)?;
+	let excess = secp::Secp256k1::commit_sum(vec![out_commit], vec![over_commit])?;
+	let pubkey = excess.to_pubkey()?;
 
 	let features = KernelFeatures::Coinbase;
 	let msg = features.kernel_sig_msg()?;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -34,7 +34,6 @@ use util::secp::constants::{
 use util::secp::key::PublicKey;
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::secp::Signature;
-use util::secp::{ContextFlag, Secp256k1};
 
 /// Serialization size limit for a single chunk/object or array.
 /// WARNING!!! You can increase the number, but never decrease
@@ -674,8 +673,7 @@ impl Writeable for Signature {
 impl Writeable for PublicKey {
 	// Write the public key in compressed form
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		let secp = Secp256k1::with_caps(ContextFlag::None);
-		writer.write_fixed_bytes(self.serialize_vec(&secp, true))?;
+		writer.write_fixed_bytes(self.serialize_vec(true))?;
 		Ok(())
 	}
 }
@@ -684,8 +682,7 @@ impl Readable for PublicKey {
 	// Read the public key in compressed form
 	fn read<R: Reader>(reader: &mut R) -> Result<Self, Error> {
 		let buf = reader.read_fixed_bytes(COMPRESSED_PUBLIC_KEY_SIZE)?;
-		let secp = Secp256k1::with_caps(ContextFlag::None);
-		let pk = PublicKey::from_slice(&secp, &buf)
+		let pk = PublicKey::from_slice(&buf)
 			.map_err(|e| Error::CorruptedData(format!("Unable to read public key, {}", e)))?;
 		Ok(pk)
 	}

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -198,8 +198,8 @@ fn build_two_half_kernels() {
 	let msg = kernel.msg_to_sign().unwrap();
 
 	// Generate a kernel with public excess and associated signature.
-	let excess = BlindingFactor::rand(&keychain.secp());
-	let skey = excess.secret_key(&keychain.secp()).unwrap();
+	let excess = BlindingFactor::rand();
+	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
 	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
 	kernel.excess_sig =

--- a/core/tests/core.rs
+++ b/core/tests/core.rs
@@ -201,7 +201,7 @@ fn build_two_half_kernels() {
 	let excess = BlindingFactor::rand();
 	let skey = excess.secret_key().unwrap();
 	kernel.excess = keychain.secp().commit(0, skey).unwrap();
-	let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+	let pubkey = &kernel.excess.to_pubkey().unwrap();
 	kernel.excess_sig =
 		aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 	kernel.verify().unwrap();

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -323,7 +323,7 @@ impl From<secp::Error> for Error {
 impl ExtendedPrivKey {
 	/// Construct a new master key from a seed value
 	pub fn new_master<H>(
-		secp: &Secp256k1,
+		_secp: &Secp256k1,
 		hasher: &mut H,
 		seed: &[u8],
 	) -> Result<ExtendedPrivKey, Error>
@@ -339,7 +339,7 @@ impl ExtendedPrivKey {
 			depth: 0,
 			parent_fingerprint: Default::default(),
 			child_number: ChildNumber::from_normal_idx(0),
-			secret_key: SecretKey::from_slice(secp, &result[..32]).map_err(Error::Ecdsa)?,
+			secret_key: SecretKey::from_slice(&result[..32]).map_err(Error::Ecdsa)?,
 			chain_code: ChainCode::from(&result[32..]),
 		})
 	}
@@ -390,8 +390,7 @@ impl ExtendedPrivKey {
 			ChildNumber::Normal { .. } => {
 				// Non-hardened key: compute public data and use that
 				hasher.append_sha512(
-					&PublicKey::from_secret_key(secp, &self.secret_key)?.serialize_vec(secp, true)
-						[..],
+					&PublicKey::from_secret_key(secp, &self.secret_key)?.serialize_vec(true)[..],
 				);
 			}
 			ChildNumber::Hardened { .. } => {
@@ -404,9 +403,8 @@ impl ExtendedPrivKey {
 
 		hasher.append_sha512(&be_n);
 		let result = hasher.result_sha512();
-		let mut sk = SecretKey::from_slice(secp, &result[..32]).map_err(Error::Ecdsa)?;
-		sk.add_assign(secp, &self.secret_key)
-			.map_err(Error::Ecdsa)?;
+		let mut sk = SecretKey::from_slice(&result[..32]).map_err(Error::Ecdsa)?;
+		sk.add_assign(&self.secret_key).map_err(Error::Ecdsa)?;
 
 		Ok(ExtendedPrivKey {
 			network: self.network,
@@ -427,7 +425,7 @@ impl ExtendedPrivKey {
 		// Compute extended public key
 		let pk: ExtendedPubKey = ExtendedPubKey::from_private::<H>(&secp, self, hasher);
 		// Do SHA256 of just the ECDSA pubkey
-		let sha2_res = hasher.sha_256(&pk.public_key.serialize_vec(&secp, true)[..]);
+		let sha2_res = hasher.sha_256(&pk.public_key.serialize_vec(true)[..]);
 		// do RIPEMD160
 		hasher.ripemd_160(&sha2_res)
 	}
@@ -477,7 +475,7 @@ impl ExtendedPubKey {
 	/// Compute the scalar tweak added to this key to get a child key
 	pub fn ckd_pub_tweak<H>(
 		&self,
-		secp: &Secp256k1,
+		_secp: &Secp256k1,
 		hasher: &mut H,
 		i: ChildNumber,
 	) -> Result<(SecretKey, ChainCode), Error>
@@ -488,14 +486,14 @@ impl ExtendedPubKey {
 			ChildNumber::Hardened { .. } => Err(Error::CannotDeriveFromHardenedKey),
 			ChildNumber::Normal { index: n } => {
 				hasher.init_sha512(&self.chain_code[..]);
-				hasher.append_sha512(&self.public_key.serialize_vec(secp, true)[..]);
+				hasher.append_sha512(&self.public_key.serialize_vec(true)[..]);
 				let mut be_n = [0; 4];
 				BigEndian::write_u32(&mut be_n, n);
 				hasher.append_sha512(&be_n);
 
 				let result = hasher.result_sha512();
 
-				let secret_key = SecretKey::from_slice(secp, &result[..32])?;
+				let secret_key = SecretKey::from_slice(&result[..32])?;
 				let chain_code = ChainCode::from(&result[32..]);
 				Ok((secret_key, chain_code))
 			}
@@ -527,12 +525,12 @@ impl ExtendedPubKey {
 	}
 
 	/// Returns the HASH160 of the chaincode
-	pub fn identifier<H>(&self, secp: &Secp256k1, hasher: &mut H) -> [u8; 20]
+	pub fn identifier<H>(&self, _secp: &Secp256k1, hasher: &mut H) -> [u8; 20]
 	where
 		H: BIP32Hasher,
 	{
 		// Do SHA256 of just the ECDSA pubkey
-		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(secp, true)[..]);
+		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(true)[..]);
 		// do RIPEMD160
 		hasher.ripemd_160(&sha2_res)
 	}
@@ -566,7 +564,6 @@ impl FromStr for ExtendedPrivKey {
 	type Err = base58::Error;
 
 	fn from_str(inp: &str) -> Result<ExtendedPrivKey, base58::Error> {
-		let s = Secp256k1::without_caps();
 		let data = base58::from_check(inp)?;
 
 		if data.len() != 78 {
@@ -587,7 +584,7 @@ impl FromStr for ExtendedPrivKey {
 			parent_fingerprint: Fingerprint::from(&data[5..9]),
 			child_number: child_number,
 			chain_code: ChainCode::from(&data[13..45]),
-			secret_key: SecretKey::from_slice(&s, &data[46..78])
+			secret_key: SecretKey::from_slice(&data[46..78])
 				.map_err(|e| base58::Error::Other(format!("Unable to read priv key, {}", e)))?,
 		})
 	}
@@ -595,7 +592,6 @@ impl FromStr for ExtendedPrivKey {
 
 impl fmt::Display for ExtendedPubKey {
 	fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let secp = Secp256k1::without_caps();
 		let mut ret = [0; 78];
 		ret[0..4].copy_from_slice(&self.network[0..4]);
 		ret[4] = self.depth as u8;
@@ -604,7 +600,7 @@ impl fmt::Display for ExtendedPubKey {
 		BigEndian::write_u32(&mut ret[9..13], u32::from(self.child_number));
 
 		ret[13..45].copy_from_slice(&self.chain_code[..]);
-		ret[45..78].copy_from_slice(&self.public_key.serialize_vec(&secp, true)[..]);
+		ret[45..78].copy_from_slice(&self.public_key.serialize_vec(true)[..]);
 		fmt.write_str(&base58::check_encode_slice(&ret[..]))
 	}
 }
@@ -613,7 +609,6 @@ impl FromStr for ExtendedPubKey {
 	type Err = base58::Error;
 
 	fn from_str(inp: &str) -> Result<ExtendedPubKey, base58::Error> {
-		let s = Secp256k1::without_caps();
 		let data = base58::from_check(inp)?;
 
 		if data.len() != 78 {
@@ -634,7 +629,7 @@ impl FromStr for ExtendedPubKey {
 			parent_fingerprint: Fingerprint::from(&data[5..9]),
 			child_number: child_number,
 			chain_code: ChainCode::from(&data[13..45]),
-			public_key: PublicKey::from_slice(&s, &data[45..78])
+			public_key: PublicKey::from_slice(&data[45..78])
 				.map_err(|e| base58::Error::Other(format!("Unable to read pub key, {}", e)))?,
 		})
 	}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -166,14 +166,14 @@ impl Keychain for ExtKeychain {
 		let keys = blind_sum
 			.positive_blinding_factors
 			.iter()
-			.filter_map(|b| b.secret_key(&self.secp).ok())
+			.filter_map(|b| b.secret_key().ok())
 			.collect::<Vec<SecretKey>>();
 		pos_keys.extend(keys);
 
 		let keys = blind_sum
 			.negative_blinding_factors
 			.iter()
-			.filter_map(|b| b.secret_key(&self.secp).ok())
+			.filter_map(|b| b.secret_key().ok())
 			.collect::<Vec<SecretKey>>();
 		neg_keys.extend(keys);
 
@@ -198,7 +198,7 @@ impl Keychain for ExtKeychain {
 		msg: &Message,
 		blinding: &BlindingFactor,
 	) -> Result<Signature, Error> {
-		let skey = &blinding.secret_key(&self.secp)?;
+		let skey = &blinding.secret_key()?;
 		let sig = self.secp.sign(msg, &skey)?;
 		Ok(sig)
 	}
@@ -245,27 +245,21 @@ mod test {
 	fn secret_key_addition() {
 		let keychain = ExtKeychain::from_random_seed(false).unwrap();
 
-		let skey1 = SecretKey::from_slice(
-			&keychain.secp,
-			&[
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 1,
-			],
-		)
+		let skey1 = SecretKey::from_slice(&[
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 1,
+		])
 		.unwrap();
 
-		let skey2 = SecretKey::from_slice(
-			&keychain.secp,
-			&[
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 2,
-			],
-		)
+		let skey2 = SecretKey::from_slice(&[
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 2,
+		])
 		.unwrap();
 
 		// adding secret keys 1 and 2 to give secret key 3
 		let mut skey3 = skey1.clone();
-		skey3.add_assign(&keychain.secp, &skey2).unwrap();
+		skey3.add_assign(&skey2).unwrap();
 
 		// create commitments for secret keys 1, 2 and 3
 		// all committing to the value 0 (which is what we do for tx_kernels)

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -177,7 +177,7 @@ impl Keychain for ExtKeychain {
 			.collect::<Vec<SecretKey>>();
 		neg_keys.extend(keys);
 
-		let sum = self.secp.blind_sum(pos_keys, neg_keys)?;
+		let sum = secp::Secp256k1::blind_sum(pos_keys, neg_keys)?;
 		Ok(BlindingFactor::from_secret_key(sum))
 	}
 
@@ -268,10 +268,7 @@ mod test {
 		let commit_3 = keychain.secp.commit(0, skey3.clone()).unwrap();
 
 		// now sum commitments for keys 1 and 2
-		let sum = keychain
-			.secp
-			.commit_sum(vec![commit_1, commit_2], vec![])
-			.unwrap();
+		let sum = secp::Secp256k1::commit_sum(vec![commit_1, commit_2], vec![]).unwrap();
 
 		// confirm the commitment for key 3 matches the sum of the commitments 1 and 2
 		assert_eq!(sum, commit_3);

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -152,7 +152,7 @@ impl ViewKey {
 		amount: u64,
 		switch: SwitchCommitmentType,
 	) -> Result<PublicKey, Error> {
-		let value_key = secp.commit_value(amount)?.to_pubkey(secp)?;
+		let value_key = secp.commit_value(amount)?.to_pubkey()?;
 		let pub_key = PublicKey::from_combination(vec![&self.public_key, &value_key])?;
 		match switch {
 			SwitchCommitmentType::None => Ok(pub_key),

--- a/keychain/src/view_key.rs
+++ b/keychain/src/view_key.rs
@@ -66,7 +66,7 @@ impl ViewKey {
 		switch_public_key.mul_assign(secp, &ext_key.secret_key)?;
 		let switch_public_key = Some(switch_public_key);
 
-		let rewind_hash = Self::rewind_hash(secp, keychain.public_root_key());
+		let rewind_hash = Self::rewind_hash(keychain.public_root_key());
 
 		Ok(Self {
 			is_floo,
@@ -80,14 +80,13 @@ impl ViewKey {
 		})
 	}
 
-	fn rewind_hash(secp: &Secp256k1, public_root_key: PublicKey) -> Vec<u8> {
-		let ser = public_root_key.serialize_vec(secp, true);
+	fn rewind_hash(public_root_key: PublicKey) -> Vec<u8> {
+		let ser = public_root_key.serialize_vec(true);
 		blake2b(32, &[], &ser[..]).as_bytes().to_vec()
 	}
 
 	fn ckd_pub_tweak<H>(
 		&self,
-		secp: &Secp256k1,
 		hasher: &mut H,
 		i: ChildNumber,
 	) -> Result<(SecretKey, ChainCode), Error>
@@ -98,14 +97,14 @@ impl ViewKey {
 			ChildNumber::Hardened { .. } => Err(BIP32Error::CannotDeriveFromHardenedKey.into()),
 			ChildNumber::Normal { index: n } => {
 				hasher.init_sha512(&self.chain_code[..]);
-				hasher.append_sha512(&self.public_key.serialize_vec(secp, true)[..]);
+				hasher.append_sha512(&self.public_key.serialize_vec(true)[..]);
 				let mut be_n = [0; 4];
 				BigEndian::write_u32(&mut be_n, n);
 				hasher.append_sha512(&be_n);
 
 				let result = hasher.result_sha512();
 
-				let secret_key = SecretKey::from_slice(secp, &result[..32])?;
+				let secret_key = SecretKey::from_slice(&result[..32])?;
 				let chain_code = ChainCode::from(&result[32..]);
 				Ok((secret_key, chain_code))
 			}
@@ -121,7 +120,7 @@ impl ViewKey {
 	where
 		H: BIP32Hasher,
 	{
-		let (secret_key, chain_code) = self.ckd_pub_tweak(secp, hasher, i)?;
+		let (secret_key, chain_code) = self.ckd_pub_tweak(hasher, i)?;
 
 		let mut public_key = self.public_key;
 		public_key.add_exp_assign(secp, &secret_key)?;
@@ -130,7 +129,7 @@ impl ViewKey {
 			Some(p) => {
 				let mut j = PublicKey(ffi::PublicKey(GENERATOR_PUB_J_RAW));
 				j.mul_assign(secp, &secret_key)?;
-				Some(PublicKey::from_combination(secp, vec![p, &j])?)
+				Some(PublicKey::from_combination(vec![p, &j])?)
 			}
 			None => None,
 		};
@@ -138,7 +137,7 @@ impl ViewKey {
 		Ok(Self {
 			is_floo: self.is_floo,
 			depth: self.depth + 1,
-			parent_fingerprint: self.fingerprint(secp, hasher),
+			parent_fingerprint: self.fingerprint(hasher),
 			child_number: i,
 			public_key,
 			switch_public_key,
@@ -154,7 +153,7 @@ impl ViewKey {
 		switch: SwitchCommitmentType,
 	) -> Result<PublicKey, Error> {
 		let value_key = secp.commit_value(amount)?.to_pubkey(secp)?;
-		let pub_key = PublicKey::from_combination(secp, vec![&self.public_key, &value_key])?;
+		let pub_key = PublicKey::from_combination(vec![&self.public_key, &value_key])?;
 		match switch {
 			SwitchCommitmentType::None => Ok(pub_key),
 			SwitchCommitmentType::Regular => {
@@ -178,18 +177,18 @@ impl ViewKey {
 		}
 	}
 
-	fn identifier<H>(&self, secp: &Secp256k1, hasher: &mut H) -> [u8; 20]
+	fn identifier<H>(&self, hasher: &mut H) -> [u8; 20]
 	where
 		H: BIP32Hasher,
 	{
-		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(secp, true)[..]);
+		let sha2_res = hasher.sha_256(&self.public_key.serialize_vec(true)[..]);
 		hasher.ripemd_160(&sha2_res)
 	}
 
-	fn fingerprint<H>(&self, secp: &Secp256k1, hasher: &mut H) -> Fingerprint
+	fn fingerprint<H>(&self, hasher: &mut H) -> Fingerprint
 	where
 		H: BIP32Hasher,
 	{
-		Fingerprint::from(&self.identifier(secp, hasher)[0..4])
+		Fingerprint::from(&self.identifier(hasher)[0..4])
 	}
 }

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -29,7 +29,6 @@ use grin_util as util;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use util::static_secp_instance;
 
 pub struct Pool<B, V>
 where
@@ -306,11 +305,7 @@ where
 	) -> Result<BlockSums, PoolError> {
 		let overage = tx.overage();
 
-		let offset = {
-			let secp = static_secp_instance();
-			let secp = secp.lock();
-			header.total_kernel_offset().add(&tx.offset, &secp)
-		}?;
+		let offset = header.total_kernel_offset().add(&tx.offset)?;
 
 		let block_sums = self.blockchain.get_block_sums(&header.hash())?;
 

--- a/pool/tests/nrd_kernel_relative_height.rs
+++ b/pool/tests/nrd_kernel_relative_height.rs
@@ -82,7 +82,7 @@ fn test_nrd_kernel_relative_height() -> Result<(), PoolError> {
 		let excess = BlindingFactor::rand();
 		let skey = excess.secret_key().unwrap();
 		kernel.excess = keychain.secp().commit(0, skey).unwrap();
-		let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
+		let pubkey = &kernel.excess.to_pubkey().unwrap();
 		kernel.excess_sig =
 			aggsig::sign_with_blinding(&keychain.secp(), &msg, &excess, Some(&pubkey)).unwrap();
 		kernel.verify().unwrap();

--- a/pool/tests/nrd_kernel_relative_height.rs
+++ b/pool/tests/nrd_kernel_relative_height.rs
@@ -79,8 +79,8 @@ fn test_nrd_kernel_relative_height() -> Result<(), PoolError> {
 		let msg = kernel.msg_to_sign().unwrap();
 
 		// Generate a kernel with public excess and associated signature.
-		let excess = BlindingFactor::rand(&keychain.secp());
-		let skey = excess.secret_key(&keychain.secp()).unwrap();
+		let excess = BlindingFactor::rand();
+		let skey = excess.secret_key().unwrap();
 		kernel.excess = keychain.secp().commit(0, skey).unwrap();
 		let pubkey = &kernel.excess.to_pubkey(&keychain.secp()).unwrap();
 		kernel.excess_sig =

--- a/servers/src/grin/server.rs
+++ b/servers/src/grin/server.rs
@@ -17,7 +17,7 @@
 //! as a facade.
 
 use crate::tor::config as tor_config;
-use crate::util::{secp, static_secp_instance};
+use crate::util::secp;
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
@@ -553,9 +553,7 @@ impl Server {
 		let scoped_vec;
 		let mut existing_onion = None;
 		if !found {
-			let secp_inst = static_secp_instance();
-			let secp = secp_inst.lock();
-			let sec_key = secp::key::SecretKey::new(&secp, &mut rand::thread_rng());
+			let sec_key = secp::key::SecretKey::new(&mut rand::thread_rng());
 			scoped_vec = vec![sec_key.clone()];
 			sec_key_vec = Some((scoped_vec).as_slice());
 

--- a/servers/src/tor/config.rs
+++ b/servers/src/tor/config.rs
@@ -313,7 +313,7 @@ mod tests {
 
 	use rand::rngs::mock::StepRng;
 
-	use crate::util::{self, secp, static_secp_instance};
+	use crate::util::{self, secp};
 
 	pub fn clean_output_dir(test_dir: &str) {
 		let _ = fs::remove_dir_all(test_dir);
@@ -328,10 +328,8 @@ mod tests {
 	fn test_service_config() -> Result<(), Error> {
 		let test_dir = "target/test_output/onion_service";
 		setup(test_dir);
-		let secp_inst = static_secp_instance();
-		let secp = secp_inst.lock();
 		let mut test_rng = StepRng::new(1_234_567_890_u64, 1);
-		let sec_key = secp::key::SecretKey::new(&secp, &mut test_rng);
+		let sec_key = secp::key::SecretKey::new(&mut test_rng);
 		output_onion_service_config(test_dir, &sec_key)?;
 		clean_output_dir(test_dir);
 		Ok(())
@@ -341,10 +339,8 @@ mod tests {
 	fn test_output_tor_config() -> Result<(), Error> {
 		let test_dir = "./target/test_output/tor";
 		setup(test_dir);
-		let secp_inst = static_secp_instance();
-		let secp = secp_inst.lock();
 		let mut test_rng = StepRng::new(1_234_567_890_u64, 1);
-		let sec_key = secp::key::SecretKey::new(&secp, &mut test_rng);
+		let sec_key = secp::key::SecretKey::new(&mut test_rng);
 		output_tor_listener_config(
 			test_dir,
 			"127.0.0.1:3415",

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -33,5 +33,5 @@ failure_derive = "0.1"
 git = "https://github.com/mwcproject/rust-secp256k1-zkp"
 #tag = "grin_integration_28"
 #path = "../../rust-secp256k1-zkp"
-version = "0.7.9"
+version = "0.7.10"
 features = ["bullet-proof-sizing"]


### PR DESCRIPTION
Related to the PRs in `rust-secp256k1-zkp` repo:
- https://github.com/mwcproject/rust-secp256k1-zkp/pull/4
- https://github.com/mwcproject/rust-secp256k1-zkp/pull/5
- https://github.com/mwcproject/rust-secp256k1-zkp/pull/6
- https://github.com/mwcproject/rust-secp256k1-zkp/pull/7

A simple secp256k1 context object is designed for type serialization/parsing functions, no explicit context is needed to avoid expensive pre-computations or dynamic allocations.

This will give a nice QoL improvement to avoid the `secp` locking for Ser/Deser.