### PR TITLE
Clean Readme Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 [![Build Status](https://dev.azure.com/mwc-project/MWC%20Project/_apis/build/status/mwcproject.mwc-node?branchName=master)](https://dev.azure.com/mwc-project/MWC%20Project/_build/latest?definitionId=2&branchName=master)
-[![Coverage Status](https://img.shields.io/codecov/c/github/mimblewimble/grin/master.svg)](https://codecov.io/gh/mimblewimble/grin)
-[![Chat](https://img.shields.io/gitter/room/grin_community/Lobby.svg)](https://gitter.im/grin_community/Lobby)
-[![Support](https://img.shields.io/badge/support-on%20gitter-brightgreen.svg)](https://gitter.im/grin_community/support)
+[![Chat](https://img.shields.io/discord/539232227360243712)](https://discord.gg/n5dZaty)
+[![Support](https://img.shields.io/badge/support-on%20Discord-brightgreen.svg)](https://discord.gg/n5dZaty)
 [![Documentation Wiki](https://img.shields.io/badge/doc-wiki-blue.svg)](https://github.com/mimblewimble/docs/wiki)
-[![Release Version](https://img.shields.io/github/release/mimblewimble/grin.svg)](https://github.com/mimblewimble/grin/releases)
-[![License](https://img.shields.io/github/license/mimblewimble/grin.svg)](https://github.com/mimblewimble/grin/blob/master/LICENSE)
+[![Release Version](https://img.shields.io/github/v/release/mwcproject/mwc-node.svg)](https://github.com/mwcproject/mwc-node/releases)
+[![License](https://img.shields.io/github/license/mwcproject/mwc-node.svg)](https://github.com/mwcproject/mwc-node/blob/master/LICENSE)
 
 # MWC
 


### PR DESCRIPTION
This PR has no effect on Consensus or any Code that is relevant to functionallity. It's only a Readme update. 

The Readme contained some dead Batch-links I either fixxed where applicaple, or removed. 
The Batch for Code Coverage does not seem applicaple without further action taken so I removed it for now. (https://codecov.io/gh/mwcproject/mwc-node would be our version of the link)