### PR TITLE
rewind bad headers, ban on explicit bad headers

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -227,6 +227,9 @@ impl Chain {
 		// Suppress any errors here in case we cannot find
 		chain.rewind_bad_block()?;
 
+		let header_head = chain.header_head()?;
+		chain.rebuild_sync_mmr(&header_head)?;
+
 		chain.log_heads()?;
 
 		Ok(chain)
@@ -259,6 +262,11 @@ impl Chain {
 					header.hash(),
 					header.height
 				);
+
+				let prev_header = self.get_previous_header(&header)?;
+				let new_head = Tip::from_header(&prev_header);
+
+				// Fix the (full) block chain.
 				if let Ok(block) = self.get_block(&hash) {
 					debug!(
 						"rewind_bad_block: found block: {} at {}",
@@ -266,7 +274,6 @@ impl Chain {
 						block.header.height
 					);
 
-					let prev_header = self.get_previous_header(&header)?;
 					debug!(
 						"rewind_bad_block: rewinding to prev: {} at {}",
 						prev_header.hash(),
@@ -278,7 +285,6 @@ impl Chain {
 					let mut batch = self.store.batch()?;
 
 					let old_head = batch.head()?;
-					let mut new_head = old_head.clone();
 
 					txhashset::extending(
 						&mut header_pmmr,
@@ -288,17 +294,42 @@ impl Chain {
 							pipe::rewind_and_apply_fork(&prev_header, ext, batch)?;
 
 							// Reset chain head.
-							new_head = Tip::from_header(&prev_header);
 							batch.save_body_head(&new_head)?;
+							batch.save_header_head(&new_head)?;
 
 							Ok(())
 						},
 					)?;
 
-					// Now delete bad block and all subsequent blocks from local db.
+					// Cleanup all subsequent bad blocks (back from old head).
 					let mut current = batch.get_block_header(&old_head.hash())?;
 					while current.height > new_head.height {
 						let _ = batch.delete_block(&current.hash());
+						current = batch.get_previous_header(&current)?;
+					}
+
+					batch.commit()?;
+				}
+
+				{
+					let mut header_pmmr = self.header_pmmr.write();
+					let mut batch = self.store.batch()?;
+
+					let old_header_head = batch.header_head()?;
+
+					txhashset::header_extending(&mut header_pmmr, &mut batch, |ext, batch| {
+						pipe::rewind_and_apply_header_fork(&prev_header, ext, batch)?;
+
+						// Reset chain head.
+						batch.save_header_head(&new_head)?;
+
+						Ok(())
+					})?;
+
+					// cleanup all subsequent bad headers (back from old header_head).
+					let mut current = batch.get_block_header(&old_header_head.hash())?;
+					while current.height > new_head.height {
+						let _ = batch.delete_block_header(&current.hash());
 						current = batch.get_previous_header(&current)?;
 					}
 

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -14,6 +14,8 @@
 
 //! Implementation of the chain block acceptance (or refusal) pipeline.
 
+use grin_core::core::hash::Hash;
+
 use crate::core::consensus;
 use crate::core::core::hash::Hashed;
 use crate::core::core::verifier_cache::VerifierCache;
@@ -408,6 +410,17 @@ fn prev_header_store(
 	Ok(prev)
 }
 
+fn check_bad_header(header: &BlockHeader) -> Result<(), Error> {
+	let bad_hashes = [Hash::from_hex(
+		"0002897182d8cf7631e86d56ad546b7cf0893bda811592aa9312ae633ce04813",
+	)?];
+	if bad_hashes.contains(&header.hash()) {
+		Err(ErrorKind::InvalidBlockProof(block::Error::Other("explicit bad header".into())).into())
+	} else {
+		Ok(())
+	}
+}
+
 /// First level of block validation that only needs to act on the block header
 /// to make it as cheap as possible. The different validations are also
 /// arranged by order of cost to have as little DoS surface as possible.
@@ -430,6 +443,9 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 		// time progression
 		return Err(ErrorKind::InvalidBlockTime.into());
 	}
+
+	// Check the header hash against a list of known bad headers.
+	check_bad_header(header)?;
 
 	// We can determine output and kernel counts for this block based on mmr sizes from previous header.
 	// Assume 0 inputs and estimate a lower bound on the full block weight.

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -14,8 +14,6 @@
 
 //! Implementation of the chain block acceptance (or refusal) pipeline.
 
-use grin_core::core::hash::Hash;
-
 use crate::core::consensus;
 use crate::core::core::hash::Hashed;
 use crate::core::core::verifier_cache::VerifierCache;
@@ -412,7 +410,7 @@ fn prev_header_store(
 
 fn check_bad_header(header: &BlockHeader) -> Result<(), Error> {
 	let bad_hashes = [Hash::from_hex(
-		"0002897182d8cf7631e86d56ad546b7cf0893bda811592aa9312ae633ce04813",
+		"00020440a401086e57e1b7a92ebb0277c7f7fd47a38269ecc6789c2a80333725",
 	)?];
 	if bad_hashes.contains(&header.hash()) {
 		Err(ErrorKind::InvalidBlockProof(block::Error::Other("explicit bad header".into())).into())

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -293,6 +293,11 @@ impl<'a> Batch<'a> {
 		Ok(())
 	}
 
+	/// Delete a block header.
+	pub fn delete_block_header(&self, h: &Hash) -> Result<(), Error> {
+		self.db.delete(&to_key(BLOCK_HEADER_PREFIX, h)[..])
+	}
+
 	/// Save block header to db.
 	pub fn save_block_header(&self, header: &BlockHeader) -> Result<(), Error> {
 		let hash = header.hash();

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -825,8 +825,11 @@ where
 	// Use underlying MMR to determine the "head".
 	let head = match handle.head_hash() {
 		Ok(hash) => {
-			let header = child_batch.get_block_header(&hash)?;
-			Tip::from_header(&header)
+			if let Ok(header) = child_batch.get_block_header(&hash) {
+				Tip::from_header(&header)
+			} else {
+				Tip::default()
+			}
 		}
 		Err(_) => Tip::default(),
 	};


### PR DESCRIPTION
- validate against explicit list of bad headers
- rewind both header_head and head if bad block on current chain

This is together with #33 which rewinds the bad block chain, and this PR rewinds the header chain also.