### PR TITLE
Automation of API Docs for the Node

### DIFF
--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -1,0 +1,20 @@
+steps:
+- script: |
+   cd /home/vsts/work/1/s/api && cargo fetch  && cargo doc --offline --no-deps
+   mkdir /home/vsts/work/1/gitpages/Node && cd /home/vsts/work/1/gitpages/Node && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
+   
+   cd  /home/vsts/work/1/gitpages/Node
+   git config user.name $(ghpages_user)
+   git checkout master
+   cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/Node/
+   echo '<meta http-equiv=refresh content=0;url=grin_api/trait.OwnerRpc.html>' > /home/vsts/work/1/gitpages/Node/index.html && \
+   git add --all
+   git commit -m"Pipelines-Bot: Updated site via $(Build.SourceVersion)";
+   git push https://$(github_pat)@github.com/mwcproject/mwcproject.github.io.git
+   
+   curl https://api.github.com/repos/$(ghpages_user)/$(ghpages_repo)/pages/builds/latest -i -v \
+       -X GET \
+       -H "Accept: application/vnd.github.mister-fantastic-preview+json" \
+       -H "Authorization: Basic $(ghpages_auth_header)"
+  displayName: 'Create and Push Docs'
+  condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,13 +24,14 @@ pr:
     include: ['*']
 
 variables:
-  RUST_BACKTRACE: '1'
+  RUST_BACKTRACE: 'FULL'
   RUSTFLAGS: '-C debug-assertions'
+  RUST_TEST_TASKS: 1
 
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
   strategy:
     matrix:
       servers:
@@ -49,17 +50,12 @@ jobs:
         CI_JOB: release
         PLATFORM: linux-amd64
   steps:
-    - script: |
-        sudo apt-get update -yqq
-        sudo apt-get purge --auto-remove clang-11 clang-format-11 llvm-11 llvm-11-dev llvm-11-tools llvm-11-runtime clang-10 clang-format-10 llvm-10 llvm-10-dev llvm-10-tools llvm-10-runtime clang-9 clang-format-9 llvm-9 llvm-9-dev llvm-9-tools llvm-9-runtime
-        sudo apt install clang-8 git curl make build-essential mesa-utils libgl1-mesa-dev openssl libssl-dev -y
-        sudo apt-get install -yqq --no-install-recommends libncursesw5-dev
-      displayName: Linux Install Dependencies
+    - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: macos
   pool:
-    vmImage: macos-latest
+    vmImage: macos-10.14
   strategy:
     matrix:
       test:
@@ -68,9 +64,7 @@ jobs:
         CI_JOB: release
         PLATFORM: macos
   steps:
-    - script: |
-        brew uninstall llvm
-      displayName: macOS Uninstall LLVM
+    - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: windows
@@ -84,9 +78,6 @@ jobs:
         CI_JOB: release
         PLATFORM: win-x64
   steps:
-    - script: |
-        choco install -y llvm
-        choco install -y openssl
-      displayName: Windows Install Dependencies
+    - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/windows-release.yml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,14 +24,16 @@ pr:
     include: ['*']
 
 variables:
-  RUST_BACKTRACE: 'FULL'
+  RUST_BACKTRACE: '1'
   RUSTFLAGS: '-C debug-assertions'
-  RUST_TEST_TASKS: 1
+  ghpages_user: 'mwcproject'
+  ghpages_repo: 'mwcproject.github.io'
+  ghpages_auth_header: '$(echo -n "${ghpages_user}:$(github_pat)" | base64);'
 
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       servers:
@@ -50,12 +52,17 @@ jobs:
         CI_JOB: release
         PLATFORM: linux-amd64
   steps:
-    - template: '.ci/install.yml'
+    - script: |
+        sudo apt-get update -yqq
+        sudo apt-get purge --auto-remove clang-11 clang-format-11 llvm-11 llvm-11-dev llvm-11-tools llvm-11-runtime clang-10 clang-format-10 llvm-10 llvm-10-dev llvm-10-tools llvm-10-runtime clang-9 clang-format-9 llvm-9 llvm-9-dev llvm-9-tools llvm-9-runtime
+        sudo apt install clang-8 git curl make build-essential mesa-utils libgl1-mesa-dev openssl libssl-dev -y
+        sudo apt-get install -yqq --no-install-recommends libncursesw5-dev
+      displayName: Linux Install Dependencies
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: macos
   pool:
-    vmImage: macos-10.14
+    vmImage: macos-latest
   strategy:
     matrix:
       test:
@@ -64,7 +71,9 @@ jobs:
         CI_JOB: release
         PLATFORM: macos
   steps:
-    - template: '.ci/install.yml'
+    - script: |
+        brew uninstall llvm
+      displayName: macOS Uninstall LLVM
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: windows
@@ -78,6 +87,20 @@ jobs:
         CI_JOB: release
         PLATFORM: win-x64
   steps:
-    - template: '.ci/install.yml'
+    - script: |
+        choco install -y llvm
+        choco install -y openssl
+      displayName: Windows Install Dependencies
     - template: '.ci/test.yml'
     - template: '.ci/windows-release.yml'
+- job: Docs
+  timeoutInMinutes: 60
+  pool:
+    vmImage: ubuntu-latest
+  strategy:
+    matrix:
+      release:
+        CI_JOB: release
+        PLATFORM: linux-amd64
+  steps:
+    - template: '.ci/pushdocs.yml'


### PR DESCRIPTION
### Proposal to automate mwc-node (API) Crate Documentation generated by rustdocs/Cargo doc

### **Preamble:**
It would be nice to automatically push new API Docs of the Node to Git Pages aswell. This was requested by @vek-kal
This can be accomplished by using an additional build step in Azure pipelines which creates the Docs, and then pushes them to the Gitpages Repo.

This PR has no Impact on Consensus or any actual Code that is connected to the Node itself. 
But it does hook into the CI Build process as its own Build Job, so it shouldn't matter if it would fail. 
Therefore the impact should be minimal.

If there are any questions or Inputs, please don't hesitate to give me a Tag @bayk.
Also take your time reviewing this as there is no haste to Push API docs out.

### **Approach/workflow:**
1. Execute Cargo Doc Command to generate Docs (only for API)
2. Clone current Git Pages Repo into extra Directory
3. Copy over Changed Docs (overwrite git pages repo locally)
4. Push Commit back to Git Pages Repo
5. Check if Github Pages Build was succesfull (so this check will fail if there is an Issue with Docs)
Im not totally sure if this check would actually get this step to fail (its the last command executed, returns a 200 code if AOK)
Step 5 might be unnecessarry/ineffective as Im not sure how long it takes for the build status to be returned.

### **Needed actions to implement this PR/workflow:** 

1. Create PAT for user with push access to mwcproject.github.io
2. Save this personal Access token as a _secret_ variable in Azure (named 'github_pat')
3. (might not be needed) explicitly add the PAT user as a member to the mwcproject.github.io Repository where our Gitpages reside

4. Merge this PR and check if it build successfully upon next release 


### **Explanations of added Values:** 
 ` ghpages_user: 'mwcproject'   `(User of Github Pages Repository - the organization account)
`  ghpages_repo: 'mwcproject.github.io'` (Github Pages Repository - that pushed code will be pushed and then availlable via http at mwcproject.github.io)
  `ghpages_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);' `(This is needed to query the Github API to check if the Pages actually rendered.)

### **Remarks** 

If there is an Issue building croaring-sys-mw then this may help https://github.com/mimblewimble/grin/issues/1189#issuecomment-403578676
Im quite sure this was an Issue isolated to my OS tho.

### **Sources:**

https://florian-rappl.de/News/Page/383/azure-pipelines-publish-to-github-pages
https://xaviergeerinck.com/post/infrastructure/deploying-gh-pages-with-azure-pipelines/
https://github.com/thebillkidy/thebillkidy.github.io/blob/development/azure-pipelines.yml


**If there are any questions, remarks or Feedback feel free to address those, Greetings MrT ☕** 