### PR TITLE
Fix Git not pushing API docs

### DIFF
--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -1,10 +1,11 @@
 steps:
 - script: |
    cd /home/vsts/work/1/s/api && cargo fetch  && cargo doc --offline --no-deps
-   mkdir -p /home/vsts/work/1/gitpages/Node && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
+   mkdir -p /home/vsts/work/1/gitpages && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
    
    git config user.name $(ghpages_user)
    git checkout master
+   mkdir -p /home/vsts/work/1/gitpages/Node
    cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/Node/
    cd  /home/vsts/work/1/gitpages/Node
    echo '<meta http-equiv=refresh content=0;url=grin_api/trait.OwnerRpc.html>' > /home/vsts/work/1/gitpages/Node/index.html && \

--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -9,6 +9,7 @@ steps:
    cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/Node/
    cd  /home/vsts/work/1/gitpages/Node
    echo '<meta http-equiv=refresh content=0;url=grin_api/trait.OwnerRpc.html>' > /home/vsts/work/1/gitpages/Node/index.html && \
+   cd  /home/vsts/work/1/gitpages/
    git add --all
    git commit -m"Pipelines-Bot: Updated site via $(Build.SourceVersion)";
    git push https://$(github_pat)@github.com/mwcproject/mwcproject.github.io.git

--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -1,9 +1,8 @@
 steps:
 - script: |
    cd /home/vsts/work/1/s/api && cargo fetch  && cargo doc --offline --no-deps
-   mkdir -p /home/vsts/work/1/gitpages/Node && cd /home/vsts/work/1/gitpages/Node && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
+   mkdir -p /home/vsts/work/1/gitpages/Node && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
    
-   cd  /home/vsts/work/1/gitpages
    git config user.name $(ghpages_user)
    git checkout master
    cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/Node/


### PR DESCRIPTION
Final Fix for the API Doc autogeneration, sorry this 1 subdir really threw me off as I couldn't test in my azure. 

This PR has no influence on consensus or any relevant code of the Node, it's merely a CI fix to move generated docs into the correct Subdir.