### PR TITLE
Optimize and fix issues at PIBD cache.

### DIFF
--- a/chain/src/pibd_params.rs
+++ b/chain/src/pibd_params.rs
@@ -28,9 +28,6 @@ pub const RANGEPROOF_SEGMENT_HEIGHT: u8 = 11;
 /// Kernel segment height assumed for requests and segment calculation
 pub const KERNEL_SEGMENT_HEIGHT: u8 = 11;
 
-/// Maximum number of received segments to cache (across all trees) before we stop requesting others
-pub const MAX_CACHED_SEGMENTS: usize = 15;
-
 /// How long the state sync should wait after requesting a segment from a peer before
 /// deciding the segment isn't going to arrive. The syncer will then re-request the segment
 pub const SEGMENT_REQUEST_TIMEOUT_SECS: i64 = 60;
@@ -38,10 +35,10 @@ pub const SEGMENT_REQUEST_TIMEOUT_SECS: i64 = 60;
 /// Number of simultaneous requests for segments we should make per available peer. Note this is currently
 /// divisible by 3 to try and evenly spread requests amount the 3 main MMRs (Bitmap segments
 /// will always be requested first)
-pub const SEGMENT_REQUEST_PER_PEER: usize = 3;
+pub const SEGMENT_REQUEST_PER_PEER: usize = 6;
 /// Maximum number of simultaneous requests. Please note, the data will be processed in a single thread, so
 /// the throughput will not be high. 12 should load CPU pretty well at the end of sync process.
-pub const SEGMENT_REQUEST_LIMIT: usize = 12;
+pub const SEGMENT_REQUEST_LIMIT: usize = 24;
 
 /// Maximum stale requests per peer. If there are more requests, no new data will be requested
 pub const STALE_REQUESTS_PER_PEER: u32 = 5;

--- a/servers/src/grin/sync/state_sync.rs
+++ b/servers/src/grin/sync/state_sync.rs
@@ -20,6 +20,7 @@ use grin_p2p::ReasonForBan;
 use grin_util::secp::rand::Rng;
 use rand::seq::SliceRandom;
 use std::sync::Arc;
+use std::{thread, time};
 
 use crate::chain::{self, pibd_params, SyncState, SyncStatus};
 use crate::core::core::{hash::Hashed, pmmr::segment::SegmentType};
@@ -246,6 +247,10 @@ impl StateSync {
 				}
 
 				if has_segmenter {
+					// Sleeping some extra time because checking request is CPU time consuming, not much optimization
+					// going through all the data. That is why at lease let's not over do with that.
+					thread::sleep(time::Duration::from_millis(500));
+
 					// Continue our PIBD process (which returns true if all segments are in)
 					match self.continue_pibd(&archive_header) {
 						Ok(true) => {

--- a/servers/src/grin/sync/syncer.rs
+++ b/servers/src/grin/sync/syncer.rs
@@ -154,8 +154,8 @@ impl SyncRunner {
 			if self.stop_state.is_stopped() {
 				break;
 			}
-
-			thread::sleep(time::Duration::from_millis(10));
+			// Grin has 10 ms here. During PIBD sync it is waste of CPU, checking will take significant resources.
+			thread::sleep(time::Duration::from_millis(500));
 
 			let currently_syncing = self.sync_state.is_syncing();
 


### PR DESCRIPTION
Optimize and fix issues at PIBD cache.

Previous version download process can stuck because late duplicate response was stored forever in cache. When cache size reached 15 elements, download stopped.

Also sync loop had waiting time 10 ms. It is too low, because checking for sync state takes CPU time. Instead we better to use that CPU time to applying requested data. With TOR normal response time 1-3 seconds, that why current sync sleep time is 500ms+500ms = 1 second. 