### PR TITLE
Make headers and blocks requests centralized to prevent requests/resp…

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -806,6 +806,10 @@ impl ChainAdapter for TrackingAdapter {
 		self.adapter
 			.receive_kernel_segment(peer, archive_header_hash, segment)
 	}
+
+	fn peer_difficulty(&self, addr: &PeerAddr, diff: Difficulty, height: u64) {
+		self.adapter.peer_difficulty(addr, diff, height)
+	}
 }
 
 impl NetAdapter for TrackingAdapter {
@@ -815,10 +819,6 @@ impl NetAdapter for TrackingAdapter {
 
 	fn peer_addrs_received(&self, addrs: Vec<PeerAddr>) {
 		self.adapter.peer_addrs_received(addrs)
-	}
-
-	fn peer_difficulty(&self, addr: &PeerAddr, diff: Difficulty, height: u64) {
-		self.adapter.peer_difficulty(addr, diff, height)
 	}
 
 	fn is_banned(&self, addr: &PeerAddr) -> bool {

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -899,6 +899,13 @@ impl ChainAdapter for Peers {
 		self.adapter
 			.receive_kernel_segment(peer, archive_header_hash, segment)
 	}
+
+	fn peer_difficulty(&self, addr: &PeerAddr, diff: Difficulty, height: u64) {
+		if let Some(peer) = self.get_connected_peer(addr) {
+			peer.info.update(height, diff);
+		}
+		self.adapter.peer_difficulty(addr, diff, height)
+	}
 }
 
 impl NetAdapter for Peers {
@@ -937,12 +944,6 @@ impl NetAdapter for Peers {
 		}
 		if let Err(e) = self.save_peers(to_save) {
 			error!("Could not save received peer addresses: {:?}", e);
-		}
-	}
-
-	fn peer_difficulty(&self, addr: &PeerAddr, diff: Difficulty, height: u64) {
-		if let Some(peer) = self.get_connected_peer(addr) {
-			peer.info.update(height, diff);
 		}
 	}
 

--- a/p2p/src/serv.rs
+++ b/p2p/src/serv.rs
@@ -613,6 +613,8 @@ impl ChainAdapter for DummyAdapter {
 	) -> Result<(), chain::Error> {
 		Ok(())
 	}
+
+	fn peer_difficulty(&self, _: &PeerAddr, _: Difficulty, _: u64) {}
 }
 
 impl NetAdapter for DummyAdapter {
@@ -620,7 +622,6 @@ impl NetAdapter for DummyAdapter {
 		vec![]
 	}
 	fn peer_addrs_received(&self, _: Vec<PeerAddr>) {}
-	fn peer_difficulty(&self, _: &PeerAddr, _: Difficulty, _: u64) {}
 	fn is_banned(&self, _: &PeerAddr) -> bool {
 		false
 	}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -859,6 +859,9 @@ pub trait ChainAdapter: Sync + Send {
 		archive_header_hash: Hash,
 		segment: Segment<TxKernel>,
 	) -> Result<(), chain::Error>;
+
+	/// Heard total_difficulty from a connected peer (via ping/pong).
+	fn peer_difficulty(&self, peer: &PeerAddr, difficulty: Difficulty, height: u64);
 }
 
 /// Additional methods required by the protocol that don't need to be
@@ -870,9 +873,6 @@ pub trait NetAdapter: ChainAdapter {
 
 	/// A list of peers has been received from one of our peers.
 	fn peer_addrs_received(&self, _: Vec<PeerAddr>);
-
-	/// Heard total_difficulty from a connected peer (via ping/pong).
-	fn peer_difficulty(&self, _: &PeerAddr, _: Difficulty, _: u64);
 
 	/// Is this peer currently banned?
 	fn is_banned(&self, addr: &PeerAddr) -> bool;

--- a/servers/src/mwc/sync.rs
+++ b/servers/src/mwc/sync.rs
@@ -15,6 +15,7 @@
 
 //! Syncing of the chain with the rest of the network
 
+mod block_headers_request_cache;
 mod body_sync;
 mod header_hashes_sync;
 mod header_sync;
@@ -24,6 +25,7 @@ pub mod sync_manager;
 mod sync_peers;
 mod sync_utils;
 mod syncer;
+
 pub use header_sync::get_locator_heights;
 
 pub use self::syncer::run_sync;

--- a/servers/src/mwc/sync/block_headers_request_cache.rs
+++ b/servers/src/mwc/sync/block_headers_request_cache.rs
@@ -1,0 +1,199 @@
+// Copyright 2024 The MWC Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mwc_chain::Chain;
+use mwc_core::core::hash::Hash;
+use mwc_p2p::{PeerAddr, Peers};
+use mwc_util::RwLock;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct HeadersRequest {
+	pub addr: PeerAddr,
+	pub head_header_hash: Option<Hash>,
+	pub height: u64,
+	pub locator: Vec<Hash>,
+}
+
+pub struct BlockRequest {
+	pub addr: PeerAddr,
+	pub height: u64,
+	pub block_hash: Hash,
+	pub opts: mwc_chain::Options,
+}
+
+/// Because of node active role, we might end up request too many data from the peers.
+/// As a result node can be flooded with too much data. It is not optimal, we want to
+/// do tracking requsts for the headers and tracking for the blocks.
+pub struct HeadersBlocksRequests {
+	chain: Arc<Chain>,
+	headers: RwLock<VecDeque<HeadersRequest>>,
+	blocks: RwLock<BTreeMap<u64, VecDeque<BlockRequest>>>,
+}
+
+impl HeadersBlocksRequests {
+	pub fn new(chain: Arc<Chain>) -> Self {
+		HeadersBlocksRequests {
+			chain,
+			headers: RwLock::new(VecDeque::new()),
+			blocks: RwLock::new(BTreeMap::new()),
+		}
+	}
+
+	pub fn add_header_request(
+		&self,
+		addr: &PeerAddr,
+		head_header_hash: Option<Hash>,
+		height: u64,
+		locator: Vec<Hash>,
+	) {
+		let mut headers = self.headers.write();
+		for req in &*headers {
+			if req.addr == *addr {
+				debug!("Ignored header request to {}, already in the Q", addr);
+				return; // request already exist, dedup it
+			}
+		}
+		debug!("Added header request to {}, for height {}", addr, height);
+		headers.push_back(HeadersRequest {
+			addr: addr.clone(),
+			head_header_hash,
+			height,
+			locator,
+		});
+	}
+
+	pub fn add_block_request(
+		&self,
+		addr: &PeerAddr,
+		height: u64,
+		block_hash: Hash,
+		opts: mwc_chain::Options,
+	) {
+		let mut blocks = self.blocks.write();
+
+		match blocks.get_mut(&height) {
+			Some(requests) => {
+				for req in &*requests {
+					if req.addr == *addr {
+						debug!(
+							"Ignored block {} request to {}, for height {}",
+							block_hash, addr, height
+						);
+						return;
+					}
+				}
+				debug!(
+					"Added block {} request to {}, for height {}",
+					block_hash, addr, height
+				);
+				requests.push_back(BlockRequest {
+					addr: addr.clone(),
+					height,
+					block_hash,
+					opts,
+				});
+			}
+			None => {
+				debug!(
+					"Added block {} request to {}, for height {}",
+					block_hash, addr, height
+				);
+				let mut req = VecDeque::new();
+				req.push_back(BlockRequest {
+					addr: addr.clone(),
+					height,
+					block_hash,
+					opts,
+				});
+				blocks.insert(height, req);
+			}
+		}
+	}
+
+	const MAX_REQUEST_PER_PEER: u32 = 3;
+
+	pub fn process_request(&self, peers: &Arc<Peers>) -> Result<(), mwc_chain::Error> {
+		let mut requests_per_peer: HashMap<PeerAddr, u32> = HashMap::new();
+
+		// process requests for heights and for blocks.
+		let head_header = self.chain.head_header()?.height;
+		{
+			// Requesting single heads chain
+			let mut headers = self.headers.write();
+			loop {
+				// Requesting single series of headers
+				match headers.pop_front() {
+					Some(head_req) => {
+						let known_header: bool = head_req
+							.head_header_hash
+							.map(|hash| self.chain.get_block_header(&hash).is_ok())
+							.unwrap_or(head_req.height <= head_header);
+						if !known_header {
+							if let Some(peer) = peers.get_connected_peer(&head_req.addr) {
+								debug!("process_request, requesting headers from {}, target height: {}", head_req.addr, head_req.height);
+								// processign single headers request at a time
+								if peer.send_header_request(head_req.locator).is_ok() {
+									*requests_per_peer.entry(head_req.addr).or_insert(0) += 1;
+									break;
+								}
+							}
+						}
+						continue;
+					}
+					None => break,
+				}
+			}
+		}
+
+		// Requesting all blocks once. I don't see how we can request just few and be not attacked.
+		// My point that if we prefer any block vs others, it will be possible to organizes attack
+		// to stale the node progress.
+		{
+			let mut blocks = self.blocks.write();
+			for (_height, requests) in &mut *blocks {
+				let mut skipped_requests = Vec::new();
+				while !requests.is_empty() {
+					let block_req = requests.pop_front().unwrap();
+					if !self.chain.block_exists(&block_req.block_hash)? {
+						if let Some(peer) = peers.get_connected_peer(&block_req.addr) {
+							debug!("process_request, requesting block from {}, target height: {} , hash: {}",
+                                        block_req.addr, block_req.height, block_req.block_hash);
+
+							let cnt = requests_per_peer.entry(block_req.addr.clone()).or_insert(0);
+							if *cnt < Self::MAX_REQUEST_PER_PEER {
+								if peer
+									.send_block_request(block_req.block_hash, block_req.opts)
+									.is_ok()
+								{
+									*cnt += 1;
+									break;
+								}
+							} else {
+								skipped_requests.push(block_req);
+							}
+						}
+					}
+				}
+				for r in skipped_requests {
+					requests.push_back(r);
+				}
+			}
+			blocks.retain(|_h, val| !val.is_empty());
+		}
+
+		Ok(())
+	}
+}

--- a/servers/src/mwc/sync/header_sync.rs
+++ b/servers/src/mwc/sync/header_sync.rs
@@ -140,7 +140,7 @@ impl HeaderSync {
 					Ok(has_more_data) => {
 						if has_more_data {
 							return SyncResponse::new(
-								SyncRequestResponses::HashMoreHeadersToApply,
+								SyncRequestResponses::HasMoreHeadersToApply,
 								Self::get_peer_capabilities(),
 								"Has more headers data to apply".into(),
 							);

--- a/servers/src/mwc/sync/sync_utils.rs
+++ b/servers/src/mwc/sync/sync_utils.rs
@@ -34,7 +34,7 @@ pub enum SyncRequestResponses {
 	WaitingForHeadersHash,
 	HeadersPibdReady,
 	HeadersReady,
-	HashMoreHeadersToApply,
+	HasMoreHeadersToApply,
 	WaitingForHeaders,
 	StatePibdReady,
 	BadState, // need update state, probably horizon was changed, need to retry


### PR DESCRIPTION
Fixed data flooding issue. Headers/blocks requests made centralized and limited by requests per seconds.
