### PR TITLE
Revert back changes for TxKernelPrintable, fee_shift

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -530,6 +530,7 @@ impl<'de> serde::de::Deserialize<'de> for OutputPrintable {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TxKernelPrintable {
 	pub features: String,
+	pub fee_shift: u8, // Keeping fee_shift for backward compability. Wallets of older are expecting that. Value must be 0
 	pub fee: u64,
 	pub lock_height: u64,
 	pub excess: String,
@@ -552,6 +553,7 @@ impl TxKernelPrintable {
 		let fee = fee_fields.fee();
 		TxKernelPrintable {
 			features,
+			fee_shift: 0,
 			fee,
 			lock_height,
 			excess: k.excess.to_hex(),

--- a/core/src/pow/common.rs
+++ b/core/src/pow/common.rs
@@ -30,19 +30,6 @@ pub trait EdgeType: PrimInt + ToPrimitive + Mul + BitOrAssign + Hash {}
 impl EdgeType for u32 {}
 impl EdgeType for u64 {}
 
-/// An edge in the Cuckoo graph, simply references two u64 nodes.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct Edge {
-	pub u: u64,
-	pub v: u64,
-}
-
-impl fmt::Display for Edge {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "(u: {}, v: {})", self.u, self.v)
-	}
-}
-
 /// An element of an adjencency list
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Link {


### PR DESCRIPTION
Found that deployment has wallets backward compatibility. Node can be newer version than the wallets. 